### PR TITLE
Fixed the moveCard() class

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -63,7 +63,7 @@ chrome.extension.sendMessage({}, function() {
   function moveCard() {
     if(card.length !== 1) return;
 
-    card.find('span.list-card-operation').trigger('click');
+    card.find('span.list-card-title').trigger('click');
     elm = document.querySelector('a.js-move-card');
 
     elm.click();


### PR DESCRIPTION
Updated the moveCard() class to fix it. It was broken because Trello had changed the span class for cards, which is what this extension uses as a shortcut to the 'move cards' menu